### PR TITLE
[codex] Add license attribution notices

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,4 +28,5 @@ Link issues (e.g., `Closes #123`) and related PRs.
 
 - [ ] Follows coding style and naming conventions
 - [ ] Updates docs/AGENTS.md if needed
+- [ ] Updates `NOTICE.md` / generated-data attribution when datasets, models, or copied third-party material change
 - [ ] Keeps commits scoped and conventional (e.g., `feat(rank): ...`)

--- a/.gitignore
+++ b/.gitignore
@@ -89,7 +89,8 @@ __pycache__/
 # Generated artifacts
 /out/
 /packs/
-/data/
+/data/*
+!/data/README.md
 *.safetensors
 
 # Research scratch

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,5 +23,8 @@ Write imperative, scoped commit messages (e.g. `feat(rank): add prune threshold`
 ## Research & Decision Records
 Treat `codex/decisions.md` as the canonical decision index. When adding or changing a DSN in `codex/dsn/`, update `codex/dsn/dsn-log.md` and either add a matching entry in `codex/decisions.md` or keep the DSN status as `Proposed`/`Experimental`. Do not mark a DSN `Accepted` when it only proves scaffolding, mechanics, or a hypothesis; record the evidence status separately and name the validation or falsification test that would promote it. For Pop Rank/theorem work, distinguish implementation instrumentation from proof of quality benefit, and keep unresolved validation gaps visible in the decision record.
 
+## License & Attribution
+When adding or changing datasets, generated JSONL samples, model checkpoints, copied snippets, or benchmark artifacts, update `NOTICE.md` and any local generator metadata. Keep generated data under `data/` ignored by default, and use `data/README.md` to document source/license expectations for regenerated files.
+
 ## Security & Configuration Tips
 Pin Python via `.python-version` (3.13) and prefer a local `.venv` for isolation. MLX targets Apple Silicon—follow upstream install guidance. Do not commit checkpoints, large datasets, or secrets; respect `.gitignore` and export artifacts via SafeTensors when needed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,4 +30,5 @@ Run these commands before opening a pull request. If CI uncovers issues unique t
 ## Release Checklist
 - Update the version in `pyproject.toml`.
 - Ensure CI is green on the latest macOS/MLX runner.
+- Review `NOTICE.md` and `data/README.md` for dataset, model, and generated-artifact attribution.
 - Tag and publish: `git tag vX.Y.Z && git push origin vX.Y.Z`.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,59 @@
+# Third-Party Notices
+
+Last checked: 2026-06-09.
+
+`mlx-plastic-rank` is licensed under the MIT License in `LICENSE`. This notice
+covers external data and model resources referenced by the repository or used by
+local generated artifacts. Runtime Python dependencies are not vendored in this
+repository; check upstream package metadata before redistributing an environment
+or binary bundle.
+
+## Data
+
+- `data/fault_codes_*.jsonl`, when generated with
+  `scripts/fault_codes_extract.py`, is derived from the Hugging Face dataset
+  `avneetsingla/industrial-fault-codes-sample`
+  (https://huggingface.co/datasets/avneetsingla/industrial-fault-codes-sample).
+  The upstream license tag is `cc-by-nc-4.0` / CC BY-NC 4.0
+  (https://creativecommons.org/licenses/by-nc/4.0/). Treat this data and packs
+  trained from it as research or prototype artifacts unless separate commercial
+  rights are resolved.
+
+- `data/industrybench_en_*.jsonl`, when generated with
+  `scripts/industrybench_extract.py`, is derived from the Hugging Face dataset
+  `alibaba-multimodal-industrial-ai/IndustryBench`
+  (https://huggingface.co/datasets/alibaba-multimodal-industrial-ai/IndustryBench).
+  The upstream license tag is `mit`. If you use this dataset in research or
+  published evaluations, cite: Bai et al. (2026), "IndustryBench: Probing the
+  Industrial Knowledge Boundaries of LLMs", arXiv:2605.10267
+  (https://arxiv.org/abs/2605.10267).
+
+- `data/domain_prompts.jsonl` is treated as local project sample data because no
+  external source is recorded in this repository. If it is regenerated from a
+  third-party source, add the source, license, and attribution here before
+  publishing or sharing the generated file.
+
+## Model Checkpoints
+
+The repository references model checkpoints in docs, tests, and scripts, but it
+does not vendor checkpoint weights. Verify the upstream card and license before
+redistributing weights, generated packs, or derived artifacts.
+
+- `mlx-community/gemma-4-12B-mxfp8` and
+  `mlx-community/gemma-4-12B-bf16` are MLX conversions of `google/gemma-4-12B`.
+  Their Hugging Face cards list `apache-2.0` and link to the Gemma 4 license
+  terms (https://ai.google.dev/gemma/docs/gemma_4_license).
+
+- `mlx-community/gemma-4-12B-it-qat-mxfp8` is used in local Gemma 4 IT QAT
+  experiments. At the check date above, its Hugging Face API/card did not expose
+  an explicit license tag. Treat it as subject to the upstream Gemma 4 / Google
+  model terms until the card is made explicit, and do not redistribute weights or
+  packs trained from it without confirming the applicable terms.
+
+- `mlx-community/Qwen2.5-1.5B-Instruct-4bit` is an MLX checkpoint whose
+  Hugging Face card lists `apache-2.0` and links to the upstream Qwen license:
+  https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct/blob/main/LICENSE.
+
+- Historical Qwen3 pilot examples in contributor docs may reference
+  `qwen3-4b-2507-mlx-4bit`. Confirm the current upstream repository and license
+  before publishing weights, packs, or evaluation artifacts based on that model.

--- a/README.md
+++ b/README.md
@@ -138,4 +138,5 @@ Run a core model and attach/detach packs on demand using domain labels:
 - RNG seeds are fixed in tests to keep MLX operations deterministic.
 
 ## License
-Licensed under the [MIT License](LICENSE).
+Licensed under the [MIT License](LICENSE). See [NOTICE.md](NOTICE.md) for
+third-party dataset/model attribution and generated-data license notes.

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,21 @@
+# Data Directory
+
+`data/` is ignored by Git except for this README. Use it for local generated
+training and evaluation JSONL files, not for checked-in datasets.
+
+Before publishing or sharing generated data:
+
+- Keep `source_dataset`, `source_dataset_url`, and license fields from the
+  extraction scripts.
+- Update `NOTICE.md` if the source dataset, model, license, or citation changes.
+- Treat `fault_codes_*.jsonl` as CC BY-NC 4.0 derived research/prototype data
+  unless commercial rights are resolved.
+- Treat `industrybench_en_*.jsonl` as MIT-licensed IndustryBench derived data
+  and cite the upstream IndustryBench paper for published research.
+
+Current local generators:
+
+- `scripts/fault_codes_extract.py` -> `fault_codes_train.jsonl`,
+  `fault_codes_eval.jsonl`
+- `scripts/industrybench_extract.py` -> `industrybench_en_train.jsonl`,
+  `industrybench_en_eval.jsonl`

--- a/scripts/fault_codes_extract.py
+++ b/scripts/fault_codes_extract.py
@@ -12,6 +12,9 @@ from typing import Any, Iterable
 
 DATASET_ID = "avneetsingla/industrial-fault-codes-sample"
 DATASET_SERVER = "https://datasets-server.huggingface.co"
+DATASET_URL = f"https://huggingface.co/datasets/{DATASET_ID}"
+DATASET_LICENSE = "CC BY-NC 4.0"
+DATASET_LICENSE_URL = "https://creativecommons.org/licenses/by-nc/4.0/"
 
 
 def clean_text(value: Any) -> str:
@@ -96,6 +99,19 @@ def build_answer(row: dict[str, Any]) -> str:
     return "\n".join(parts)
 
 
+def dataset_notice(dataset: str) -> dict[str, str]:
+    notice = {"source_dataset_url": f"https://huggingface.co/datasets/{dataset}"}
+    if dataset == DATASET_ID:
+        notice.update(
+            {
+                "source_license": DATASET_LICENSE,
+                "source_license_url": DATASET_LICENSE_URL,
+                "source_attribution": DATASET_ID,
+            }
+        )
+    return notice
+
+
 def build_example(row: dict[str, Any], dataset: str) -> dict[str, Any] | None:
     code = clean_text(row.get("code"))
     brand = clean_text(row.get("brand"))
@@ -110,6 +126,7 @@ def build_example(row: dict[str, Any], dataset: str) -> dict[str, Any] | None:
     return {
         "id": source_id,
         "source_dataset": dataset,
+        **dataset_notice(dataset),
         "source_row_idx": row.get("_row_idx"),
         "code": code,
         "brand": brand,
@@ -201,6 +218,7 @@ def main() -> None:
     )
     summary = {
         "dataset": args.dataset,
+        **dataset_notice(args.dataset),
         "source_rows": len(rows),
         "examples": len(examples),
         "train_rows": len(train_rows),

--- a/scripts/industrybench_extract.py
+++ b/scripts/industrybench_extract.py
@@ -12,6 +12,12 @@ from typing import Any, Iterable
 
 DATASET_ID = "alibaba-multimodal-industrial-ai/IndustryBench"
 DATASET_SERVER = "https://datasets-server.huggingface.co"
+DATASET_URL = f"https://huggingface.co/datasets/{DATASET_ID}"
+DATASET_LICENSE = "MIT"
+DATASET_CITATION = (
+    "Bai et al. (2026), IndustryBench: Probing the Industrial Knowledge Boundaries of LLMs, "
+    "arXiv:2605.10267"
+)
 LANGUAGE_FIELDS = {
     "zh": ("question", "answer"),
     "en": ("question_en", "answer_en"),
@@ -120,6 +126,19 @@ def build_prompt(
     return "\n".join(parts).strip()
 
 
+def dataset_notice(dataset: str) -> dict[str, str]:
+    notice = {"source_dataset_url": f"https://huggingface.co/datasets/{dataset}"}
+    if dataset == DATASET_ID:
+        notice.update(
+            {
+                "source_license": DATASET_LICENSE,
+                "source_attribution": DATASET_ID,
+                "source_citation": DATASET_CITATION,
+            }
+        )
+    return notice
+
+
 def build_example(
     row: dict[str, Any],
     language: str,
@@ -147,6 +166,7 @@ def build_example(
     return {
         "id": f"{source_id}:{language}",
         "source_dataset": dataset,
+        **dataset_notice(dataset),
         "source_row_idx": row.get("_row_idx"),
         "source_id": source_id,
         "language": language,
@@ -278,6 +298,7 @@ def main() -> None:
     eval_out = args.eval_out or default_output("industrybench", suffix, "eval")
     summary = {
         "dataset": args.dataset,
+        **dataset_notice(args.dataset),
         "source_rows": len(rows),
         "examples": len(examples),
         "languages": list(languages),

--- a/tests/test_fault_codes_extract.py
+++ b/tests/test_fault_codes_extract.py
@@ -15,10 +15,13 @@ SAMPLE_ROW = {
 
 
 def test_build_example_creates_diagnostic_prompt():
-    example = fault_codes_extract.build_example(SAMPLE_ROW, "dataset/id")
+    example = fault_codes_extract.build_example(SAMPLE_ROW, fault_codes_extract.DATASET_ID)
 
     assert example is not None
     assert example["id"] == "abb-10-fault-code-solution"
+    assert example["source_dataset_url"] == fault_codes_extract.DATASET_URL
+    assert example["source_license"] == "CC BY-NC 4.0"
+    assert example["source_license_url"] == "https://creativecommons.org/licenses/by-nc/4.0/"
     assert example["domain"] == "industrial_fault_diagnostics"
     assert "Manufacturer: ABB" in example["prompt"]
     assert "Fault code: 10" in example["prompt"]

--- a/tests/test_industrybench_extract.py
+++ b/tests/test_industrybench_extract.py
@@ -25,12 +25,15 @@ def test_build_example_formats_pack_ready_text():
         include_knowledge=False,
         knowledge_char_limit=8,
         metadata_mode="full",
-        dataset="dataset/id",
+        dataset=industrybench_extract.DATASET_ID,
     )
 
     assert example is not None
     assert example["id"] == "42:en"
     assert example["source_row_idx"] == 7
+    assert example["source_dataset_url"] == industrybench_extract.DATASET_URL
+    assert example["source_license"] == "MIT"
+    assert "arXiv:2605.10267" in example["source_citation"]
     assert example["domain"] == "industrial procurement"
     assert "Question:\nWhich part should be replaced?" in example["text"]
     assert example["text"].endswith("Answer:\nReplace the worn bearing.")


### PR DESCRIPTION
## Summary

Adds third-party resource notes for external datasets and model checkpoints referenced by docs/scripts, plus guardrails so future dataset/model changes keep attribution with generated artifacts when those artifacts are published.

## Changes

- Add `NOTICE.md` that states no third-party datasets, generated JSONL files, model checkpoints, or dependency source trees are vendored.
- Add `data/README.md` for local generated-data handling while keeping generated data ignored.
- Add source/license/citation metadata to the fault-code and IndustryBench extraction outputs.
- Add attribution reminders to AGENTS.md, README, CONTRIBUTING, and the PR template.

## Validation

- `uv run pytest -q`
- `uv run ruff check`
- `git diff --check`