### PR TITLE
[codex] Clarify notice scope

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -3,35 +3,32 @@
 Last checked: 2026-06-09.
 
 `mlx-plastic-rank` is licensed under the MIT License in `LICENSE`. This notice
-covers external data and model resources referenced by the repository or used by
-local generated artifacts. Runtime Python dependencies are not vendored in this
-repository; check upstream package metadata before redistributing an environment
-or binary bundle.
+covers external data and model resources referenced by repository docs,
+examples, and local experiment scripts.
 
-## Data
+No third-party datasets, generated JSONL files, model checkpoints, or dependency
+source trees are vendored in this repository. Before publishing generated data,
+trained packs, checkpoint-derived artifacts, environments, or binary bundles,
+carry the applicable upstream license, attribution, and citation into that
+artifact.
 
-- `data/fault_codes_*.jsonl`, when generated with
-  `scripts/fault_codes_extract.py`, is derived from the Hugging Face dataset
+## External Datasets
+
+- The fault-code pilot references the Hugging Face dataset
   `avneetsingla/industrial-fault-codes-sample`
   (https://huggingface.co/datasets/avneetsingla/industrial-fault-codes-sample).
   The upstream license tag is `cc-by-nc-4.0` / CC BY-NC 4.0
-  (https://creativecommons.org/licenses/by-nc/4.0/). Treat this data and packs
+  (https://creativecommons.org/licenses/by-nc/4.0/). Treat local data and packs
   trained from it as research or prototype artifacts unless separate commercial
   rights are resolved.
 
-- `data/industrybench_en_*.jsonl`, when generated with
-  `scripts/industrybench_extract.py`, is derived from the Hugging Face dataset
+- The IndustryBench pilot references the Hugging Face dataset
   `alibaba-multimodal-industrial-ai/IndustryBench`
   (https://huggingface.co/datasets/alibaba-multimodal-industrial-ai/IndustryBench).
   The upstream license tag is `mit`. If you use this dataset in research or
   published evaluations, cite: Bai et al. (2026), "IndustryBench: Probing the
   Industrial Knowledge Boundaries of LLMs", arXiv:2605.10267
   (https://arxiv.org/abs/2605.10267).
-
-- `data/domain_prompts.jsonl` is treated as local project sample data because no
-  external source is recorded in this repository. If it is regenerated from a
-  third-party source, add the source, license, and attribution here before
-  publishing or sharing the generated file.
 
 ## Model Checkpoints
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # mlx-plastic-rank
 
-Local low-rank adaptation experiments for MLX. The practical goal is a general-capable base model that can load small domain "skill packs"; the Pop Rank research question is whether LoRA rank can describe useful added capability, not just adapter size.
+Local low-rank adaptation experiments for MLX. The practical goal is a general-capable base model that can load small domain "skill packs"; the Pop Rank research question is whether LoRA rank can describe useful added capability, not just adapter size.[^pop-theorem]
 
 ## Current Thesis
 Static LoRA rank is normally treated as a fixed hyperparameter. Pop Rank explores a different path: let training discover where adapter capacity is useful, measure that rank allocation, and then test whether the discovered heterogeneous map can deliver similar quality with fewer exported adapter bytes.
 
-This is still research. The repo now has working mechanics for dynamic active-rank gates, frozen heterogeneous continuation, fresh training from a discovered rank map, and a rank ledger for measuring effective rank, slack, and pack overlap. The current evidence is quality-positive on one local industrial-domain experiment; it is not proof of a general theorem.
+This is still research. The repo now has working mechanics for dynamic active-rank gates, frozen heterogeneous continuation, fresh training from a discovered rank map, and a rank ledger for measuring effective rank, slack, and pack overlap. The current evidence is quality-positive on one local industrial-domain experiment; it is not proof of a general theorem.[^pop-theorem]
 
 ## Current Best Signal
-Fault-code maintenance pack experiment on `mlx-community/gemma-4-12B-it-qat-mxfp8`, evaluated with 300 answer-only held-out samples and 8 generation-check examples:
+Fault-code maintenance pack experiment on `mlx-community/gemma-4-12B-it-qat-mxfp8`, evaluated with 300 answer-only held-out samples and 8 generation-check examples:[^fault-codes]
 
 | Model/pack | Size | Effective rank | Answer PPL | Token Acc. | Generation solution-overlap |
 | --- | ---: | ---: | ---: | ---: | ---: |
@@ -68,14 +68,14 @@ Traditional pruning and distillation discard parameters permanently. Plastic ran
 - To continue a trained heterogeneous pack with fixed ranks, use `--resume-pack SOURCE_PACK`. To train fresh weights from a discovered heterogeneous rank map, use `--rank-map-from-pack SOURCE_PACK`.
 
 ### IndustryBench Pilot
-Use Alibaba's IndustryBench as a small industrial QA pack probe. The extractor keeps source metadata in JSON fields while letting the training text stay clean.
+Use Alibaba's IndustryBench as a small industrial QA pack probe.[^industrybench] The extractor keeps source metadata in JSON fields while letting the training text stay clean.
 - Extract a small English split: `uv run python scripts/industrybench_extract.py --language en --source-limit 512 --train-size 128 --eval-size 32 --metadata-mode none --train-out data/industrybench_en_train.jsonl --eval-out data/industrybench_en_eval.jsonl`
 - Baseline IT QAT eval: `uv run --extra packs packs eval --base mlx-community/gemma-4-12B-it-qat-mxfp8 --loader mlx-vlm --data-path data/industrybench_en_eval.jsonl --chat-template --sequence-length 256 --num-samples 32 --batch-size 1 --out out/industrybench_gemma4_it_baseline.json --csv out/industrybench_gemma4_it_baseline.csv`
 - No-shrink heavy pilot pack: `uv run --extra packs packs create --name industrybench-en-gemma4-it-heavy-smoke --base mlx-community/gemma-4-12B-it-qat-mxfp8 --loader mlx-vlm --layers attn.q_proj,attn.k_proj,attn.v_proj --data data/industrybench_en_train.jsonl --chat-template --steps 20 --batch-size 1 --sequence-length 256 --learning-rate 1e-5 --target-compression 0.7 --profile heavy`
 - First result: the pack exported and applied successfully, with q/v rank 64, k rank 32, and size 91.75 MB. On the 32-row held-out split it changed logits (`max_logit_diff=3.0`) but worsened PPL by 1.45%, so this is an end-to-end mechanics proof, not a quality win.
 
 ### Industrial Fault-Code Pilot
-Use `avneetsingla/industrial-fault-codes-sample` for the first practical industrial maintenance pack. It has 3,000 English fault-code rows with `brand`, `code`, `description`, and `solution` fields. License is `cc-by-nc-4.0`, so treat this as research/prototyping data unless licensing is resolved.
+Use `avneetsingla/industrial-fault-codes-sample` for the first practical industrial maintenance pack.[^fault-codes] It has 3,000 English fault-code rows with `brand`, `code`, `description`, and `solution` fields. License is `cc-by-nc-4.0`, so treat this as research/prototyping data unless licensing is resolved.
 - Extract train/eval JSONL: `uv run python scripts/fault_codes_extract.py --train-size 2400 --eval-size 300 --train-out data/fault_codes_train.jsonl --eval-out data/fault_codes_eval.jsonl`
 - Baseline answer-only eval: `uv run --extra packs packs eval --base mlx-community/gemma-4-12B-it-qat-mxfp8 --loader mlx-vlm --data-path data/fault_codes_eval.jsonl --chat-template --loss-mode answer --sequence-length 256 --num-samples 300 --batch-size 4 --out out/fault_codes_gemma4_it_answer_baseline_300.json --csv out/fault_codes_gemma4_it_answer_baseline_300.csv`
 - Rank-16 pilot pack: `uv run --extra packs packs create --name fault-codes-gemma4-it-answer-r16-100 --base mlx-community/gemma-4-12B-it-qat-mxfp8 --loader mlx-vlm --layers attn.q_proj,attn.k_proj,attn.v_proj --data data/fault_codes_train.jsonl --chat-template --loss-mode answer --steps 100 --batch-size 1 --sequence-length 256 --learning-rate 5e-5 --rank 16 --profile heavy --lora-dropout 0.05`
@@ -136,6 +136,13 @@ Run a core model and attach/detach packs on demand using domain labels:
 - `packs` commands require `mlx-lm`; Gemma 4 any-to-any support also requires `mlx-vlm`, and speech IO support uses `mlx-audio` (all install with `uv pip install -e '.[packs]'`).
 - Packs enforce `.lora.{A,B,alpha}` tensor schema, fp16 matrices, and fp32 alpha. Lite packs default to a 10 MB cap; heavy packs allow larger SSD-loaded adapters.
 - RNG seeds are fixed in tests to keep MLX operations deterministic.
+
+## Research Footnotes
+[^pop-theorem]: Vasile Pop, "Relations between ranks of matrix polynomials", arXiv:2010.00634 [math.RA], submitted October 1, 2020. Theorem 1 gives a rank identity for matrix polynomials; in this repo it is rank-accounting intuition, not validation that Pop Rank improves LoRA quality.
+
+[^industrybench]: Alibaba Multimodal Industrial AI, `alibaba-multimodal-industrial-ai/IndustryBench`, MIT-licensed Hugging Face dataset. Its dataset card requests citation of Bai et al. (2026), "IndustryBench: Probing the Industrial Knowledge Boundaries of LLMs", arXiv:2605.10267.
+
+[^fault-codes]: Avneet Singla, `avneetsingla/industrial-fault-codes-sample`, Hugging Face dataset tagged `cc-by-nc-4.0`. Treat experiments or packs trained on this source as research/prototype artifacts unless separate commercial rights are resolved.
 
 ## License
 Licensed under the [MIT License](LICENSE). See [NOTICE.md](NOTICE.md) for

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Run a core model and attach/detach packs on demand using domain labels:
 - RNG seeds are fixed in tests to keep MLX operations deterministic.
 
 ## Research Footnotes
-[^pop-theorem]: Vasile Pop, "Relations between ranks of matrix polynomials", arXiv:2010.00634 [math.RA], submitted October 1, 2020. Theorem 1 gives a rank identity for matrix polynomials; in this repo it is rank-accounting intuition, not validation that Pop Rank improves LoRA quality.
+[^pop-theorem]: Vasile Pop, "Relations between ranks of matrix polynomials", arXiv:2010.00634 [math.RA], submitted October 1, 2020. See also Vasile Pop and Alexandru Negrescu, "Three New Proofs of the Theorem rank f(M) + rank g(M) = rank (f,g)(M) + rank [f,g](M)", *Mathematics* 2024, 12(3), 360, https://doi.org/10.3390/math12030360. The theorem gives a rank identity for matrix polynomials; in this repo it is rank-accounting intuition, not validation that Pop Rank improves LoRA quality.
 
 [^industrybench]: Alibaba Multimodal Industrial AI, `alibaba-multimodal-industrial-ai/IndustryBench`, MIT-licensed Hugging Face dataset. Its dataset card requests citation of Bai et al. (2026), "IndustryBench: Probing the Industrial Knowledge Boundaries of LLMs", arXiv:2605.10267.
 

--- a/data/README.md
+++ b/data/README.md
@@ -7,7 +7,8 @@ Before publishing or sharing generated data:
 
 - Keep `source_dataset`, `source_dataset_url`, and license fields from the
   extraction scripts.
-- Update `NOTICE.md` if the source dataset, model, license, or citation changes.
+- Update `NOTICE.md` when a source dataset, model, license, or citation is
+  referenced by repository docs/scripts or shipped with a published artifact.
 - Treat `fault_codes_*.jsonl` as CC BY-NC 4.0 derived research/prototype data
   unless commercial rights are resolved.
 - Treat `industrybench_en_*.jsonl` as MIT-licensed IndustryBench derived data


### PR DESCRIPTION
## Summary

Clarifies that `NOTICE.md` covers external resources referenced by docs/scripts, not ignored local generated JSONL files as distributed artifacts. Adds README footnotes for the research/data sources used in the experiments.

## Changes

- State explicitly that no third-party datasets, generated JSONL files, model checkpoints, or dependency source trees are vendored.
- Reframe the dataset section around external datasets referenced by pilots.
- Keep generated-file handling guidance in `data/README.md`.
- Add README footnotes for Vasile Pop's matrix-polynomial rank theorem, the Pop/Negrescu MDPI follow-up proofs paper, IndustryBench, and the industrial fault-code dataset.

## Validation

- `git diff --check`